### PR TITLE
Update __init__.py to update sip/pjsip loaded status in hass.data

### DIFF
--- a/custom_components/asterisk/__init__.py
+++ b/custom_components/asterisk/__init__.py
@@ -45,9 +45,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if event.name == "PeerlistComplete":
             _LOGGER.debug("SIP loaded.")
             sip_loaded = True
+            hass.data[DOMAIN][entry.entry_id][SIP_LOADED] = True
         elif event.name == "EndpointListComplete":
             _LOGGER.debug("PJSIP loaded.")
             pjsip_loaded = True
+            hass.data[DOMAIN][entry.entry_id][PJSIP_LOADED] = True
         
         if sip_loaded and pjsip_loaded:
             _LOGGER.debug("Both SIP and PJSIP loaded. Loading platforms.")


### PR DESCRIPTION
both sip_loaded and pjsip loaded must be true for devices to be created and they are set locally but never written back to the hass.data object so both are never true at the same time.  This was introduced in the may 8th commit 9e6c1e4